### PR TITLE
Add React frontend skeleton

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+/dist

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Video Labeler</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.1.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react';
+import VideoUploader from './components/VideoUploader.jsx';
+import StatusViewer from './components/StatusViewer.jsx';
+import LabelSelector from './components/LabelSelector.jsx';
+import ClipPlayer from './components/ClipPlayer.jsx';
+
+export default function App() {
+  const [videoId, setVideoId] = useState(null);
+
+  return (
+    <div style={{ padding: '1rem', fontFamily: 'sans-serif' }}>
+      <h1>Video Labeler</h1>
+      <VideoUploader onUploaded={setVideoId} />
+      {videoId && (
+        <>
+          <StatusViewer videoId={videoId} />
+          <LabelSelector videoId={videoId} />
+          <ClipPlayer videoId={videoId} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ClipPlayer.jsx
+++ b/frontend/src/components/ClipPlayer.jsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+
+export default function ClipPlayer({ videoId }) {
+  const [url, setUrl] = useState(null);
+
+  useEffect(() => {
+    const fetchUrl = async () => {
+      try {
+        const res = await fetch(`/api/merged/${videoId}`);
+        const blob = await res.blob();
+        setUrl(URL.createObjectURL(blob));
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchUrl();
+  }, [videoId]);
+
+  if (!url) return null;
+  return (
+    <div>
+      <h3>Merged Clip</h3>
+      <video src={url} controls style={{ maxWidth: '100%' }} />
+    </div>
+  );
+}

--- a/frontend/src/components/LabelSelector.jsx
+++ b/frontend/src/components/LabelSelector.jsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+
+export default function LabelSelector({ videoId }) {
+  const [labels, setLabels] = useState([]);
+  const [selected, setSelected] = useState([]);
+
+  useEffect(() => {
+    const fetchLabels = async () => {
+      try {
+        const res = await fetch('/api/labels');
+        const json = await res.json();
+        setLabels(json.labels || []);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchLabels();
+  }, []);
+
+  const handleSubmit = async () => {
+    try {
+      await fetch(`/api/labels/${videoId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ labels: selected }),
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const toggle = (label) => {
+    setSelected((prev) =>
+      prev.includes(label) ? prev.filter((l) => l !== label) : [...prev, label]
+    );
+  };
+
+  return (
+    <div>
+      <h3>Select Labels</h3>
+      {labels.map((label) => (
+        <label key={label} style={{ marginRight: '1rem' }}>
+          <input
+            type="checkbox"
+            checked={selected.includes(label)}
+            onChange={() => toggle(label)}
+          />
+          {label}
+        </label>
+      ))}
+      <div>
+        <button onClick={handleSubmit}>Submit Labels</button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/StatusViewer.jsx
+++ b/frontend/src/components/StatusViewer.jsx
@@ -1,0 +1,20 @@
+import React, { useEffect, useState } from 'react';
+
+export default function StatusViewer({ videoId }) {
+  const [status, setStatus] = useState('pending');
+
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      try {
+        const res = await fetch(`/api/status/${videoId}`);
+        const json = await res.json();
+        setStatus(json.status);
+      } catch (err) {
+        console.error(err);
+      }
+    }, 3000);
+    return () => clearInterval(interval);
+  }, [videoId]);
+
+  return <p>Status: {status}</p>;
+}

--- a/frontend/src/components/VideoUploader.jsx
+++ b/frontend/src/components/VideoUploader.jsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+
+export default function VideoUploader({ onUploaded }) {
+  const [file, setFile] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleUpload = async () => {
+    if (!file) return;
+    setLoading(true);
+    const data = new FormData();
+    data.append('file', file);
+    try {
+      const res = await fetch('/api/upload', {
+        method: 'POST',
+        body: data,
+      });
+      const json = await res.json();
+      onUploaded(json.id);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <input type="file" accept="video/*" onChange={(e) => setFile(e.target.files[0])} />
+      <button onClick={handleUpload} disabled={loading}>Upload</button>
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- setup `frontend` folder with `package.json`, `vite` config and HTML entry
- add React components for uploading videos, viewing status, selecting labels and showing merged clips

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68629379087c832f9e02b4274d15b584